### PR TITLE
Update templatefunc.go

### DIFF
--- a/templatefunc.go
+++ b/templatefunc.go
@@ -300,7 +300,12 @@ func parseFormToStruct(form url.Values, objT reflect.Type, objV reflect.Value) e
 		formValues := form[tag]
 		var value string
 		if len(formValues) == 0 {
-			continue
+			defaultValue := fieldT.Tag.Get("default")
+			if defaultValue != "" {
+				value = defaultValue
+			} else {
+				continue
+			}
 		}
 		if len(formValues) == 1 {
 			value = formValues[0]


### PR DESCRIPTION
ParseForm support default value

Useage:

type getData struct{
	Area int    `form:"Area" default:"1"`
}
